### PR TITLE
Order Option Values by label when returned for GraphQL usage and also…

### DIFF
--- a/src/Entity/Query/CiviCRM/Query.php
+++ b/src/Entity/Query/CiviCRM/Query.php
@@ -96,6 +96,9 @@ class Query extends QueryBase implements QueryInterface {
         'offset' => $this->range['start'],
       ];
     }
+    if ($this->entityType->get('civicrm_entity') == 'option_value') {
+      $params['options']['sort'] = 'label ASC';
+    }
 
     if ($this->count) {
       return $this->civicrmApi->getCount($this->entityType->get('civicrm_entity'), $params);

--- a/src/Plugin/Deriver/Fields/EntityFieldDeriver.php
+++ b/src/Plugin/Deriver/Fields/EntityFieldDeriver.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\autismontario_solr_modifications\Plugin\Deriver\Fields;
+
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\TypedData\ComplexDataDefinitionInterface;
+use Drupal\Core\TypedData\ListDataDefinitionInterface;
+use Drupal\graphql\Utility\StringHelper;
+use Drupal\graphql_core\Plugin\Deriver\EntityFieldDeriverBase;
+
+class EntityFieldDeriver extends EntityFieldDeriverBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDerivativeDefinitionsFromFieldDefinition(FieldDefinitionInterface $fieldDefinition, array $basePluginDefinition) {
+    $itemDefinition = $fieldDefinition->getItemDefinition();
+    if (!($itemDefinition instanceof ComplexDataDefinitionInterface) || !$propertyDefinitions = $itemDefinition->getPropertyDefinitions()) {
+      return [];
+    }
+
+    $tags = array_merge($fieldDefinition->getCacheTags(), ['entity_field_info']);
+    $maxAge = $fieldDefinition->getCacheMaxAge();
+    $contexts = $fieldDefinition->getCacheContexts();
+
+    $entityTypeId = $fieldDefinition->getTargetEntityTypeId();
+    $entityType = $this->entityTypeManager->getDefinition($entityTypeId);
+    $supportsBundles = $entityType->hasKey('bundle');
+    $fieldName = $fieldDefinition->getName();
+    $fieldBundle = $fieldDefinition->getTargetBundle() ?: '';
+
+    $derivative = [
+      'parents' => [StringHelper::camelCase($entityTypeId, $supportsBundles ? $fieldBundle : '')],
+      'name' => StringHelper::propCase($fieldName . 'Jma'),
+      'description' => $fieldDefinition->getDescription(),
+      'field' => $fieldName,
+      'schema_cache_tags' => $tags,
+      'schema_cache_contexts' => $contexts,
+      'schema_cache_max_age' => $maxAge,
+    ] + $basePluginDefinition;
+
+    if (count($propertyDefinitions) === 1) {
+      $propertyDefinition = reset($propertyDefinitions);
+      $derivative['type'] = $propertyDefinition->getDataType();
+      $derivative['property'] = key($propertyDefinitions);
+    }
+    else {
+      $derivative['type'] = StringHelper::camelCase('field', $entityTypeId, $supportsBundles ? $fieldBundle : '', $fieldName);
+    }
+
+    // Fields are usually multi-value. Simplify them for the schema if they are
+    // configured for cardinality 1 (only works for configured fields).
+    if (!(($storageDefinition = $fieldDefinition->getFieldStorageDefinition()) && !$storageDefinition->isMultiple()) || in_array($fieldName, ['custom_898', 'custom_897', 'custom_899'])) {
+      $derivative['type'] = StringHelper::listType($derivative['type']);
+    }
+    if (in_array($fieldName, ['custom_898', 'custom_897', 'custom_899'])) {
+      switch ($fieldName) {
+        case 'custom_897':
+          $derivative['optionGroupId'] = 232;
+          break;
+
+        case 'custom_898':
+          $derivative['optionGroupId'] = 233;
+          break;
+
+        case 'custom_899':
+          $derivative['optionGroupId'] = 105;
+          break;
+
+      }
+    }
+    return ["$entityTypeId-$fieldName-$fieldBundle-jma" => $derivative];
+  }
+}

--- a/src/Plugin/Deriver/Fields/EntityFieldDeriver.php
+++ b/src/Plugin/Deriver/Fields/EntityFieldDeriver.php
@@ -50,10 +50,10 @@ class EntityFieldDeriver extends EntityFieldDeriverBase {
 
     // Fields are usually multi-value. Simplify them for the schema if they are
     // configured for cardinality 1 (only works for configured fields).
-    if (!(($storageDefinition = $fieldDefinition->getFieldStorageDefinition()) && !$storageDefinition->isMultiple()) || in_array($fieldName, ['custom_898', 'custom_897', 'custom_899'])) {
+    if (!(($storageDefinition = $fieldDefinition->getFieldStorageDefinition()) && !$storageDefinition->isMultiple()) || in_array($fieldName, ['custom_898', 'custom_897', 'custom_899', 'custom_954', 'custom_953'])) {
       $derivative['type'] = StringHelper::listType($derivative['type']);
     }
-    if (in_array($fieldName, ['custom_898', 'custom_897', 'custom_899'])) {
+    if (in_array($fieldName, ['custom_898', 'custom_897', 'custom_899', 'custom_954', 'custom_953'])) {
       switch ($fieldName) {
         case 'custom_897':
           $derivative['optionGroupId'] = 232;
@@ -65,6 +65,14 @@ class EntityFieldDeriver extends EntityFieldDeriverBase {
 
         case 'custom_899':
           $derivative['optionGroupId'] = 105;
+          break;
+
+        case 'custom_954':
+          $derivative['optionGroupId'] = 231;
+          break;
+
+        case 'custom_953':
+          $derivative['optionGroupId'] = 236;
           break;
 
       }

--- a/src/Plugin/GraphQL/Fields/Entity/EntityField.php
+++ b/src/Plugin/GraphQL/Fields/Entity/EntityField.php
@@ -60,7 +60,7 @@ class EntityField extends EntityFieldBase {
       $result = $item->get($property)->getValue();
       if (!empty($definition['optionGroupId'])) {
         if (!$result instanceof MarkupInterface) {
-          $result = \civicrm_api3('OptionValue', 'getsingle', ['option_group_id' => $definition['optionGroupId'], 'value' => $result])['label'];
+          $result = \civicrm_api3('OptionValue', 'get', ['sequential' => 1, 'option_group_id' => $definition['optionGroupId'], 'value' => $result])['values'][0]['label'];
         }
       }
       $result = $result instanceof MarkupInterface ? $result->__toString() : $result;

--- a/src/Plugin/GraphQL/Fields/Entity/EntityField.php
+++ b/src/Plugin/GraphQL/Fields/Entity/EntityField.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\autismontario_solr_modifications\Plugin\GraphQL\Fields\Entity;
+
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\graphql\GraphQL\Cache\CacheableValue;
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql_core\Plugin\GraphQL\Fields\EntityFieldBase;
+use GraphQL\Type\Definition\ResolveInfo;
+use Drupal\Component\Render\MarkupInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\Entity;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldItemInterface;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Type\Definition\WrappingType;
+
+/**
+ * @GraphQLField(
+ *   id = "entity_field_jma",
+ *   secure = true,
+ *   weight = -2,
+ *   deriver = "Drupal\autismontario_solr_modifications\Plugin\Deriver\Fields\EntityFieldDeriver",
+ * )
+ */
+class EntityField extends EntityFieldBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    if ($value instanceof FieldableEntityInterface) {
+      $definition = $this->getPluginDefinition();
+      $name = $definition['field'];
+
+      if ($value->hasField($name)) {
+        /** @var \Drupal\Core\Field\FieldItemListInterface $items */
+        $items = $value->get($name);
+        $access = $items->access('view', NULL, TRUE);
+
+        if ($access->isAllowed()) {
+          foreach ($items as $item) {
+            $output = !empty($definition['property']) ? $this->resolveItem($item, $args, $context, $info) : $item;
+
+            yield new CacheableValue($output, [$access]);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function resolveItem($item, array $args, ResolveContext $context, ResolveInfo $info) {
+    if ($item instanceof FieldItemInterface) {
+      $definition = $this->getPluginDefinition();
+      $property = $definition['property'];
+      $result = $item->get($property)->getValue();
+      if (!empty($definition['optionGroupId'])) {
+        if (!$result instanceof MarkupInterface) {
+          $result = \civicrm_api3('OptionValue', 'getsingle', ['option_group_id' => $definition['optionGroupId'], 'value' => $result])['label'];
+        }
+      }
+      $result = $result instanceof MarkupInterface ? $result->__toString() : $result;
+
+      $type = $info->returnType;
+      $type = $type instanceof WrappingType ? $type->getWrappedType(TRUE) : $type;
+      if ($type instanceof ScalarType) {
+        $result = is_null($result) ? NULL : $type->serialize($result);
+      }
+
+      if ($result instanceof ContentEntityInterface && $result->isTranslatable() && $language = $context->getContext('language', $info)) {
+        if ($result->hasTranslation($language)) {
+          $result = $result->getTranslation($language);
+        }
+      }
+
+      return $result;
+    }
+  }
+
+}


### PR DESCRIPTION
… re-write content of Custom fields to ensure that all values are returned and that they are the labels

@monishdeb this moves some of the changes I have been making to the graphql contrib module into here and also does an alternate fix to https://github.com/JMAConsulting/biz.jmaconsulting.ao/pull/21 by defining specific fields so we actually don't have to alter the API result. This means the current Search API integrations don't break. Also I was nervous about the other alternative breaking the Full listing view as well